### PR TITLE
Log-Based Registry: phase 1 proposal

### DIFF
--- a/proposals/Log-Based-Registry.md
+++ b/proposals/Log-Based-Registry.md
@@ -6,85 +6,81 @@
 * Make malicious activity detectable
 * Enable package state replication (mirroring)
 
-# Design
-
-## Package Log
+# Package Log
 
 For each package, a registry maintains an append-only package log.
 This log is the canonical record of the package state and contains cryptographic information that makes it possible to verify its integrity.
 Information can be derived from the log and used by some consumers, but other consumers and auditors will want to directly read and verify the log itself.
 
-## Log Entries
+## Package Entry
 
-A package log is a sequence of typed *entries*. Each entry contains the following fields.
+A package log is a sequence of typed Package Entries which represent events in the life of a package.
 
-| Field | Value Type | Description |
-| ----- | ---------- | ----------- |
-| prev | hash or `null` | the previous entry in the log |
-| version | always "0.1.0" | the registry log protocol version |
-| time | ISO 8601 timestamp | when the entry was created |
-| author | public key | the key of the entry author |
-| kind | [Entry Type](#Entry-Types) | this entry's type |
-| contents | object | entry type-specific fields |
-
-e.g.
-
-```json
-{
-    "prev": <hash>,
-    "version": "0.1.0",
-    "time": "2022-05-11T11:08:00Z",
-    "author": <public key>,
-    "type": "release",
-    "contents": {
-        "version": "1.14.0",
-        "digest": <hash>
+```protobuf
+message PackageEntry {
+    // The previous entry in the log.
+    // First entry of a log has no previous entry.
+    optional string prev = 1;
+    // The warg protocol version.
+    // Encoded using semver 2.0.
+    // Only legal value currently is "0.1.0".
+    string version = 2;
+    // The time when this entry was created
+    // Format is ISO 8601 timestamp
+    string time = 3;
+    
+    // The content specific to this entry type
+    oneof content {
+        Init init = 1;
+        UpdateAuth update_auth = 2;
+        Release release = 3;
+        Yank yank = 4;
     }
 }
 ```
 
-## Log Structure
+### Initialize Package (`init`)
 
-Each *entry* is submitted as the payload of a JWS signed with the author's private key.
-The registry operator then signs the JWS to indicate acceptance of the entry.
+Creates a new package and begins the associated log.
 
-<p align="center"><img src="https://i.imgur.com/HYcgqMy.png" width="500px"></p>
+```protobuf
+message Init {
+    // The hash algorithm used by this package to link entries.
+    string algorithm = 1;
+    // The key for the author of this entry.
+    string key = 2;
+}
+```
 
-## Transparency Logs
-
-Registries should with some frequency publish the payload digest of the log head and their signature to a transparency log (e.g. [Rekor](https://github.com/sigstore/rekor)).
-
-## Entry Types
-
-*Note: none of the "Entry Types" have yet been assigned final names/mnemonics for use in the `kind` field.*
-
-With the exception of the Initialize Log entry, which may be issued by any key, entries are only valid if the key which signed them is granted permission for that entry type by the log.
-
-### Initialize Package (`init-package`)
-
-Creates a new package with a specific name and begins the associated log.
-
-* **Fields**
-  * `name` - string
 * **Validation**
   * Must always be the first entry in the log.
-  * Requires that no package with that name exists in this registry.
+  * The signature on this entry must be by the key specified in the `key` field.
 * **Effects**
-  * Registry guarantees exclusive ownership of the package name.
   * Permits the author to perform Assign Role.
 
-**Note:** Registries may choose to reject `Initialize Log` entries that do not conform to some registry policy
+**Note:** Registries may choose to reject `init` entries that do not conform to some registry policy
 (e.g. it could enforce ACME-based domain package namespaces).
 
 ### Update Authorization (`update-auth`)
 
 Assigns a role to a key.
 
-* **Fields**
-  * `key` - public key
-  * `allow` - list of entry type strings
-  * `deny` - list of entry type strings
+```protobuf
+message UpdateAuth {
+    string key = 1;
+    repeated Permission allow = 2;
+    repeated Permission deny = 3;
+}
+
+enum Permission {
+    UpdateAuth = 1;
+    Release = 2;
+    Yank = 3;
+}
+```
+
 * **Validation**
+  * This entry was signed by a key with the `update-auth` permission.
   * The key was previously authorized for all types in the deny list
 * **Effects**
   * The key is now able to create entries with the specified allow types
@@ -94,10 +90,17 @@ Assigns a role to a key.
 
 Makes a new version of the package available.
 
-* **Fields**
-  * `version` - a semantic version string
-  * `digest` - content hash
+```protobuf
+message Release {
+    // The semver 2.0 version of the release.
+    string version = 1;
+    // The labeled hash of the release contents.
+    string digest = 2;
+}
+```
+
 * **Validation**
+  * This entry was signed by a key with the `release` permission.
   * Requires that no other Release has had the same version.
 * **Effects**
   * Creates a new package release.
@@ -107,63 +110,102 @@ Makes a new version of the package available.
 
 An assertion by the maintainer that "this release is not fit for use". Does not alter the release, but may cause the release to be excluded from default query results.
 
-* **Fields**
-  * `version` - a semantic version string
+```protobuf
+message Yank {
+    // The semver 2.0 version of the release to yank.
+    string version = 1;
+}
+```
+
 * **Validation**
+  * This entry was signed by a key with the `yank` permission.
   * The package version had state`"released"`
 * **Effects**
   * The package version has state `"yanked"`
 
-# Open Questions
+# Operator Log
 
-## Hashing Scheme
+Each registry also has exactly one operator log.
+This log is the canonical record of the registry operator's state, which is currently just the set of keys that are valid over time.
 
-Define the way that payloads/envelopes/etc. are hashed and canonical digests are obtained. Define any mechanisms for identifying and migrating hash algorithms.
+## Operator Entry
+A package log is a sequence of typed Operator Entries which represent events in the life of the registry.
 
-Define a clear recovery plan for the scenario where a hash is discovered to be weak enough to enable [pre-image attacks](https://en.wikipedia.org/wiki/Preimage_attack).
+```protobuf
+message OperatorEntry {
+    // The previous entry in the log.
+    // First entry of a log has no previous entry.
+    optional string prev = 1;
+    // The warg protocol version.
+    // Encoded using semver 2.0.
+    // Only legal value currently is "0.1.0".
+    string version = 2;
+    // The time when this entry was created
+    // Format is ISO 8601 timestamp
+    string time = 3;
+    
+    // The content specific to this entry type
+    oneof content {
+        Init init = 1;
+        UpdateAuth update_auth = 2;
+    }
+}
+```
 
-## Hash Indirection
+### Initialize (`init`)
 
-There may be places where some entry content is large enough that directly including it significantly affects the size of the overall JWS.
-In these cases, it may make sense to instead include only a hash of the content and provide some way of retrieving the content.
+```protobuf
+message Init {
+    // The hash algorithm used by this package to link entries.
+    string algorithm = 1;
+    // The key for the author of this entry.
+    string key = 2;
+}
+```
 
-## Arbitrary Metadata
+### Update Authorization (`update-auth`)
 
-Maintainers may want to attach arbitrary metadata to released versions. This would be supported by an entry type (tentatively called annotate) that allows arbitrary contents ignored by the registry protocol.
+```protobuf
+message UpdateAuth {
+    string key = 1;
+    repeated Permission allow = 2;
+    repeated Permission deny = 3;
+}
 
-Maintainers may want to grant permission to other entities to attach metadata. For example, a validator that reproduces their component build.
+enum Permission {
+    UpdateAuth = 1;
+    // When
+    Commit = 2;
+}
+```
 
-### Use Cases
+# Registry DAG
 
-1. Security Scanning - the log grants access to a security scanning tool which appends CVE information to the log.
-2. Association - the log grants access to a software publisher who can choose whether or not to publicly “own” the project.
-3. Certification - the log grants access to a certification body (i.e. FIPS) who can evaluate the software and grant certifications.
-4. Reproducibility - the log grants access to a reproducible build tool who can use the instructions in the log to rebuild the software packages and testify on the log that the resulting builds had the same hashes.
+The Registry DAG is a log-backed map. For each key that is a package name `package:foobar`, the map always points to the head entry of the log at that point. The changes to this map are stored in the backing log, which as a result contains a total ordering of all log entries.
 
-### Options
+# Appendix
 
-* Allow annotation entries in the log for the latest and other versions (in-log annotations)
-* Allow each release to begin a branch containing only annotations and potentially delegations (in-branch annotations)
-* Add a role that can be granted for making annotations only (role-based annotation)
-* Add an entry type that grants one-time permission to annotate a version (delegation)
+## Hashes
+Hashes are represented as strings in the following way.
 
-## Operator Entries
+```bnf
+<hash-algorithm> ::= "SHA256"
 
-Annotation, and potentially other future entries, may need to be performed by operators. This can be represented by a role `"operator"`. Registries will publicly identify valid operator keys and timestamps will be used to identify whether a key is/was valid when it signed an entry.
+; A hash encoded with the name of the algorithm used to make it
+<labeled-hash> ::= <hash-algorithm> ":" <hash-bytes-b64>
 
-## Re-Assigning Package Names
+; Used in cases where the hash algorithm can be inferred
+<unlabeled-hash> ::= <hash-bytes-b64>
+```
 
-Registry operators may want to re-assign a package name to new owners if a package is not updated for a long length of time. This must be considered a reset of trust in the package name and automatically upgrading across these boundaries must be prevented. This boundary may be used to reset the effective log length since it may obsolete prior package state.
+## Signatures
+Signatures and keys are represented as strings in the following way.
 
-## Registry Health
+```bnf
+<sig-algorithm> ::= "ECDSA"
 
-As new contents are added to the registry over time, the proportion of contents that contains some vulnerability will tend to increase. It is worth considering if anything can be done to ameliorate this.
+<signature> ::= <sig-algorithm> ":" <signature-bytes-b64>
 
-### Options
+<key> ::= <sig-algorithm> ":" <key-bytes-b64>
+```
 
-* Enable registries to associate a time-to-live with each action on a package or release, so that inactive packages are removed automatically.
-* Enable registries to determine some "health" score for each package or release, so that users are alerted to and can address the health issues of their dependencies
-
-## Protocol Versioning
-
-To support future iterations of this protocol, this proposal contains a versioning field. In the future, this can be used to introduce a new version and allow logs to monotonically increase in version to adopt new features. Another approach would be to encode the version into the entry type names in a standard way. This has the advantage that it is harder for implementations to accidentally ignore the version information there.


### PR DESCRIPTION
[Rendered](https://github.com/bytecodealliance/SIG-Registries/blob/proposal/log-based-registry/proposals/Log-Based-Registry.md)

I've worked with @npmccallum and @lann to combine their sketches into a unified phase 1 proposal for a log-based registry. The Open Questions section contains a number of remaining decisions which should be discussed and either incorporated or determined to be out of the MVP scope.

References to "hash(es)" and "public keys" are intentionally ambiguous in the initial draft, resolving how these are represented is an open question (see topics "Hashing Scheme" and "Hash Indirection") as different design choices are available. As per our previous vote, the JOSE standard will be employed; JWKs and other JOSE features will be used where keys, signatures, and hashes are needed.

Discussions for open questions
- [Annotations](https://github.com/bytecodealliance/SIG-Registries/issues/27)
- [Operator Entries](https://github.com/bytecodealliance/SIG-Registries/issues/28)