### PR TITLE
Add notes for 2022-07-13.md

### DIFF
--- a/notes/2022-07-13.md
+++ b/notes/2022-07-13.md
@@ -1,0 +1,17 @@
+## July 13th - SIG Registries meeting
+|          |      | 
+| -------- | -------- |
+| Attending  | Luke Wagner, Peter Huene, Bailey Hayes, Michelle Dhanani, Lann Martin, Brian Hardock, Nicholas Farshidmehr, Roman Volosatovs, Isabella, jlbirch
+| Note Taker | 
+
+### Agenda
+
+- Update on cargo component
+    - Close to generating, building, and running components (pending proposals)
+    - Peter is working on tooling for linking components
+- Glossary merged ([#6](https://github.com/bytecodealliance/SIG-Registries/pull/6))
+- Rename Entities to Packages ([#23](https://github.com/bytecodealliance/SIG-Registries/issues/23))
+- [registry](https://github.com/bytecodealliance/registry) discussion
+    - [async support discussion](https://github.com/bytecodealliance/registry/issues/1)
+- Profiles discussion 
+    - [WASI Preview2 presentation](https://github.com/WebAssembly/meetings/blob/main/wasi/2022/presentations/2022-06-30-gohman-wasi-preview2.pdf)


### PR DESCRIPTION
This catches us back up where all of our current meeting notes are archived in this repo.